### PR TITLE
Create user_info on novel login

### DIFF
--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,2 @@
+/* eslint-disable import/prefer-default-export */
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,5 +1,6 @@
 import firebase from 'firebase/app';
 import 'firebase/auth';
+import { API_BASE } from './api';
 
 const signIn = () => {
   const provider = new firebase.auth.GoogleAuthProvider();
@@ -10,4 +11,12 @@ const signOut = () => {
   firebase.auth().signOut();
 };
 
-export { signIn, signOut };
+// call  DRF endpoint to get-or-create the UserInfo row
+const getOrCreateUser = (payload) =>
+  fetch(`${API_BASE}/get-or-create-user`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(payload),
+  }).then((r) => r.json());
+
+export { signIn, signOut, getOrCreateUser };

--- a/src/utils/context/authContext.js
+++ b/src/utils/context/authContext.js
@@ -1,54 +1,104 @@
-// Context API Docs: https://beta.reactjs.org/learn/passing-data-deeply-with-context
+// // Context API Docs: https://beta.reactjs.org/learn/passing-data-deeply-with-context
+
+// 'use client';
+
+// import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+// import { firebase } from '@/utils/client';
+
+// const AuthContext = createContext();
+
+// AuthContext.displayName = 'AuthContext'; // Context object accepts a displayName string property. React DevTools uses this string to determine what to display for the context. https://reactjs.org/docs/context.html#contextdisplayname
+
+// function AuthProvider(props) {
+//   const [user, setUser] = useState(null);
+
+//   // there are 3 states for the user:
+//   // null = application initial state, not yet loaded
+//   // false = user is not logged in, but the app has loaded
+//   // an object/value = user is logged in
+
+//   useEffect(() => {
+//     firebase.auth().onAuthStateChanged((fbUser) => {
+//       if (fbUser) {
+//         setUser(fbUser);
+//       } else {
+//         setUser(false);
+//       }
+//     }); // creates a single global listener for auth state changed
+//   }, []);
+
+//   const value = useMemo(
+//     // https://reactjs.org/docs/hooks-reference.html#usememo
+//     () => ({
+//       user,
+//       userLoading: user === null,
+//       // as long as user === null, will be true
+//       // As soon as the user value !== null, value will be false
+//     }),
+//     [user],
+//   );
+
+//   return <AuthContext.Provider value={value} {...props} />;
+// }
+// const AuthConsumer = AuthContext.Consumer;
+
+// const useAuth = () => {
+//   const context = useContext(AuthContext);
+
+//   if (context === undefined) {
+//     throw new Error('useAuth must be used within an AuthProvider');
+//   }
+//   return context;
+// };
+
+// export { AuthProvider, useAuth, AuthConsumer };
 
 'use client';
 
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { firebase } from '@/utils/client';
+import { getOrCreateUser } from '@/utils/auth';
 
 const AuthContext = createContext();
-
-AuthContext.displayName = 'AuthContext'; // Context object accepts a displayName string property. React DevTools uses this string to determine what to display for the context. https://reactjs.org/docs/context.html#contextdisplayname
+AuthContext.displayName = 'AuthContext';
 
 function AuthProvider(props) {
-  const [user, setUser] = useState(null);
-
-  // there are 3 states for the user:
-  // null = application initial state, not yet loaded
-  // false = user is not logged in, but the app has loaded
-  // an object/value = user is logged in
+  const [user, setUser] = useState(null); // null | false | object
 
   useEffect(() => {
-    firebase.auth().onAuthStateChanged((fbUser) => {
+    // This subscribes to Firebase auth state. It fires whenever login status changes.
+    const unsub = firebase.auth().onAuthStateChanged((fbUser) => {
       if (fbUser) {
-        setUser(fbUser);
+        // Supply defaults from Firebase to your Django API
+        getOrCreateUser({
+          uid: fbUser.uid,
+          display_name: fbUser.displayName, // becomes display_name
+          googleEmail: fbUser.email, // becomes google_email
+        }).then((serverUser) => {
+          setUser({ fbUser, ...serverUser }); // merge raw Firebase + your DB row
+        });
       } else {
         setUser(false);
       }
-    }); // creates a single global listener for auth state changed
+    });
+    return () => unsub();
   }, []);
 
   const value = useMemo(
-    // https://reactjs.org/docs/hooks-reference.html#usememo
     () => ({
       user,
       userLoading: user === null,
-      // as long as user === null, will be true
-      // As soon as the user value !== null, value will be false
     }),
     [user],
   );
 
   return <AuthContext.Provider value={value} {...props} />;
 }
-const AuthConsumer = AuthContext.Consumer;
 
 const useAuth = () => {
-  const context = useContext(AuthContext);
-
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return context;
+  const ctx = useContext(AuthContext);
+  if (ctx === undefined) throw new Error('useAuth must be used within an AuthProvider');
+  return ctx;
 };
 
-export { AuthProvider, useAuth, AuthConsumer };
+export { AuthProvider, useAuth };


### PR DESCRIPTION
This pull request enhances the authentication flow by integrating the backend user creation endpoint with the frontend authentication context. The main improvement is that after a user logs in with Firebase, the app now ensures a corresponding user record exists in the backend (Django/DRF), and merges that data with the Firebase user object for use throughout the app.

**Authentication and User Context Integration:**

* Added a new `getOrCreateUser` function in `src/utils/auth.js` that calls the backend API to create or retrieve the user record after Firebase authentication.
* Updated `AuthProvider` in `src/utils/context/authContext.js` to call `getOrCreateUser` after Firebase login, merging backend user data with the Firebase user object and storing it in context.
* Ensured cleanup of the Firebase auth state listener on component unmount in `AuthProvider`.

**API Utility:**

* Introduced a new `API_BASE` constant in `src/utils/api.js` to centralize the backend API base URL, supporting environment configuration.
* Updated imports in `src/utils/auth.js` to use the new `API_BASE` constant for API requests.

Closes #73 