### PR TITLE
updates to service scheduling page (just service details for mvp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-app-router-with-firebase-auth",
       "version": "0.1.0",
       "dependencies": {
+        "@headlessui/react": "^2.2.7",
         "@heroicons/react": "^2.2.0",
         "bootstrap": "^5.3.3",
         "firebase": "^8.2.0",
@@ -445,6 +446,59 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz",
       "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A=="
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.28",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.28.tgz",
+      "integrity": "sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.8",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.4"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
@@ -598,6 +652,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.7.tgz",
+      "integrity": "sha512-WKdTymY8Y49H8/gUc/lIyYK1M+/6dq0Iywh4zTZVAaiTDprRfioxSgD0wnXTQTBpjpGJuTL1NO/mqEvc//5SSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.26.16",
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/interactions": "^3.25.0",
+        "@tanstack/react-virtual": "^3.13.9",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/@heroicons/react": {
@@ -1038,10 +1112,45 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.1.tgz",
+      "integrity": "sha512-hmH1IhHlcQ2lSIxmki1biWzMbGgnhdxJUM0MFfzc71Rv6YAzhlx4kX3GYn4VNcjCeb6cdPv4RZ5vunV4kgMZYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.5",
+        "@react-aria/utils": "^3.30.1",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.5.tgz",
+      "integrity": "sha512-EweYHOEvMwef/wsiEqV73KurX/OqnmbzKQa2fLxdULbec5+yDj6wVGaRHIzM4NiijIDe+bldEl5DG05CAKOAHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.1",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.5.tgz",
-      "integrity": "sha512-xEwGKoysu+oXulibNUSkXf8itW0npHHTa6c4AyYeZIJyRoegeteYuFpZUBPtIDE8RfHdNsSmE1ssOkxRnwbkuQ==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       },
@@ -1049,7 +1158,55 @@
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.1.tgz",
+      "integrity": "sha512-zETcbDd6Vf9GbLndO6RiWJadIZsBU2MMm23rBACXLmpRztkrIqPEb2RVdlLaq1+GklDx0Ii6PfveVjx+8S5U6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.32.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
+      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.32.0.tgz",
+      "integrity": "sha512-t+cligIJsZYFMSPFMvsJMjzlzde06tZMOIOFa1OV5Z0BcMowrb2g4mB57j/9nP28iJIRYn10xCniQts+qadrqQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@restart/hooks": {
@@ -1391,6 +1548,33 @@
         "@tailwindcss/oxide": "4.1.12",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.12"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/json5": {
@@ -2214,6 +2398,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -6569,6 +6762,12 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
@@ -6838,6 +7037,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/warning": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     ]
   },
   "dependencies": {
+    "@headlessui/react": "^2.2.7",
     "@heroicons/react": "^2.2.0",
     "bootstrap": "^5.3.3",
     "firebase": "^8.2.0",

--- a/src/app/service/[id]/page.js
+++ b/src/app/service/[id]/page.js
@@ -1,19 +1,132 @@
 'use client';
 
-// stretch goal but service details page or maybe we will call it ServiceSchedulingPage (we route here from service card "book" btn on the category details page. will show details of the service and the stylists that offer it (drop down menu stretch). and it will show the time slots of available appointmenet, client can click btn to "select time" on each wihch should route to login and then to booking form
-import React from 'react';
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable import/no-extraneous-dependencies */
+
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { ChevronDownIcon } from '@heroicons/react/20/solid';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { getServiceById, getStylistsByService } from '../../../api/servicesData';
 
 export default function ServiceSchedulingpage({ params }) {
   const { id } = params;
+  const [serviceDetails, setServiceDetails] = useState(null);
+
+  // placeholder (you’ll fill with “stylists who offer this service” later)
+  const [selectedStylist, setSelectedStylist] = useState(null);
+  const [serviceStylists, setServiceStylists] = useState([]);
+
+  // placeholder slots (replace with real availability later)
+  const timeSlots = ['10:00 AM', '10:30 AM', '11:00 AM', '11:30 AM', '1:00 PM', '1:30 PM', '2:00 PM', '2:30 PM', '3:00 PM', '3:30 PM', '4:00 PM'];
+
+  useEffect(() => {
+    getServiceById(id).then((data) => {
+      setServiceDetails(data);
+    });
+  }, [id]);
+
+  useEffect(() => {
+    getStylistsByService(id).then((data) => {
+      setServiceStylists(data);
+    });
+  }, [id]);
 
   return (
-    <div>
-      <h1>Service Scheduling Page</h1>
-      <p>Service ID: {id}</p>
+    <div className="bg-white">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
+        {/* 2-col layout */}
+        <div className="lg:grid lg:grid-cols-12 lg:gap-8">
+          {/* LEFT: Details */}
+          <div className="lg:col-span-7">
+            <div className="space-y-6">
+              <div>
+                <h1 className="!text-3xl sm:!text-4xl !font-bold !tracking-tight !text-gray-900">{serviceDetails?.name}</h1>
+                <p className="!mt-2 !text-pink-600 !font-semibold">${serviceDetails?.price}</p>
+              </div>
+
+              <div className="prose !prose-p:mt-0 !text-gray-600">
+                <p>{serviceDetails?.description}</p>
+              </div>
+
+              {/* Image */}
+              <div className="rounded-2xl ring-1 ring-gray-200/70 shadow-sm overflow-hidden">
+                <div className="aspect-[4/3] bg-gray-100">
+                  <img alt={serviceDetails?.name} src={serviceDetails?.image_url} className="h-full w-full object-cover" />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* RIGHT: Stylist select + calendar */}
+          <aside className="mt-10 lg:mt-0 lg:col-span-5 lg:pl-8">
+            <div className="sticky top-24 space-y-6">
+              {/* Select */}
+              <div className="flex justify-end">
+                <Menu as="div" className="relative inline-block text-left">
+                  <MenuButton className="inline-flex items-center gap-x-2 rounded-xl bg-white px-4 py-2 text-sm font-medium text-gray-900 ring-1 ring-gray-300 hover:bg-gray-50 focus:outline-none">
+                    {selectedStylist?.display_name || 'Choose stylist'}
+                    <ChevronDownIcon aria-hidden="true" className="size-5 text-gray-400" />
+                  </MenuButton>
+                  <MenuItems transition className="absolute right-0 z-10 mt-2 w-56 origin-top-right rounded-xl bg-white ring-1 ring-black/5 shadow-lg outline-none data-closed:scale-95 data-closed:opacity-0 transition data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in">
+                    <div className="py-1">
+                      {serviceStylists.map((s) => (
+                        <MenuItem key={s.id}>
+                          <button type="button" onClick={() => setSelectedStylist(s)} className="block w-full px-4 py-2 text-left text-sm text-gray-700 data-focus:bg-gray-100">
+                            {s.display_name}
+                          </button>
+                        </MenuItem>
+                      ))}
+                    </div>
+                  </MenuItems>
+                </Menu>
+              </div>
+
+              {/* Calendar Card */}
+              <div className="rounded-2xl ring-1 ring-gray-200 shadow-sm p-4 sm:p-6">
+                {/* Placeholder calendar header (weekdays) */}
+                <div className="mb-4">
+                  <div className="grid grid-cols-7 text-center text-xs font-semibold text-gray-500">
+                    <div>Mon</div>
+                    <div>Tue</div>
+                    <div>Wed</div>
+                    <div>Thu</div>
+                    <div>Fri</div>
+                    <div className="!text-pink-600">Sat</div>
+                    <div className="!text-pink-600">Sun</div>
+                  </div>
+                  <div className="mt-2 grid grid-cols-7 gap-2 text-sm">
+                    {Array.from({ length: 28 }).map((_, i) => (
+                      <button key={i} type="button" className="aspect-square rounded-lg border border-gray-200 hover:border-pink-400 hover:ring-1 hover:ring-pink-300" aria-label={`Day ${i + 1}`} />
+                    ))}
+                  </div>
+                </div>
+
+                {/* Available time slots */}
+                <h3 className="text-sm font-semibold text-gray-900 mb-3">{selectedStylist?.display_name || 'All stylists'} — Available times</h3>
+                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                  {timeSlots.map((t) => (
+                    <button key={t} type="button" className="rounded-lg border border-gray-200 px-3 py-2 text-sm text-gray-700 hover:border-pink-400 hover:ring-1 hover:ring-pink-300 hover:shadow-sm transition">
+                      {t}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Book CTA (disabled until login in MVP flow) */}
+                <div className="mt-4 flex justify-end">
+                  <button type="button" className="rounded-xl bg-pink-500 px-4 py-2 text-white font-medium shadow hover:bg-pink-600 focus:outline-none">
+                    Select time…
+                  </button>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
     </div>
   );
 }
+
 ServiceSchedulingpage.propTypes = {
   params: PropTypes.shape({
     id: PropTypes.string.isRequired,


### PR DESCRIPTION
This pull request introduces a new, fully functional service scheduling page that displays service details, allows users to select a stylist, and shows available time slots for booking. The implementation leverages new UI dependencies and fetches data dynamically for both service details and stylists.

**UI and Feature Enhancements:**

* Replaced the placeholder service scheduling page with a detailed layout that shows service information, an image, and a stylist selection dropdown using `@headlessui/react` and `@heroicons/react` components. The page also includes a calendar grid and available time slots for booking. ([src/app/service/[id]/page.jsL3-R129](diffhunk://#diff-9139c2aae6c75e56c01de83229c43757c6b18ba4f248aed267008541ffae0628L3-R129))

**Data Fetching and State Management:**

* Added hooks to fetch service details and the list of stylists offering the service using `getServiceById` and `getStylistsByService`, storing results in local state. ([src/app/service/[id]/page.jsL3-R129](diffhunk://#diff-9139c2aae6c75e56c01de83229c43757c6b18ba4f248aed267008541ffae0628L3-R129))

**Dependency Updates:**

* Added `@headlessui/react` as a new dependency in `package.json` to support accessible UI components.