### PR TITLE
User specificity for services

### DIFF
--- a/src/app/category/[id]/page.js
+++ b/src/app/category/[id]/page.js
@@ -65,7 +65,8 @@ export default function CategoryDetailsPage({ params }) {
 
                   <p className="mt-1 text-sm text-gray-500">{service.description}</p>
 
-                  {isAdmin(user) && (
+                  {/* {isAdmin(user) && ( */}
+                  {service.owner_uid === user?.uid && (
                     <div className="relative z-20 mt-2 flex items-center gap-3">
                       {/* EDIT */}
                       <OverlayTrigger placement="bottom" overlay={<Tooltip id={`tooltip-edit-${service.id}`}>Edit Service</Tooltip>}>

--- a/src/components/forms/ServiceForm.js
+++ b/src/components/forms/ServiceForm.js
@@ -12,9 +12,9 @@ import PropTypes from 'prop-types';
 import { getServiceStylistOptions } from '../../api/userData';
 import { getCategories } from '../../api/categoriesData';
 import { createService, updateService } from '../../api/servicesData';
+import { useAuth } from '../../utils/context/authContext';
 
 const initialState = {
-  // id: '',
   name: '',
   description: '',
   duration: '',
@@ -30,6 +30,7 @@ export default function ServiceForm({ serviceObj = initialState }) {
   const [stylistOptions, setStylistOptions] = useState([]);
   const [categoryOptions, setCategoryOptions] = useState([]);
   const router = useRouter();
+  const { user } = useAuth();
 
   useEffect(() => {
     getCategories().then(setCategoryOptions);
@@ -48,6 +49,7 @@ export default function ServiceForm({ serviceObj = initialState }) {
         category: serviceObj.category,
         image_url: serviceObj.image_url,
         active: serviceObj.active,
+        // owner_uid: serviceObj.owner_uid, don't need this bc it's not being updated
         stylist_ids: [],
       }));
 
@@ -118,6 +120,7 @@ export default function ServiceForm({ serviceObj = initialState }) {
     if (serviceObj?.id) {
       updateService(payload).then(() => router.push('/'));
     } else {
+      payload.owner_uid = user.uid;
       createService(payload).then(() => router.push('/'));
     }
   };


### PR DESCRIPTION
This pull request updates service ownership logic to ensure that only the owner of a service can edit it, and that new services are correctly attributed to their creator. The changes affect both the service display page and the service form, integrating user authentication and ownership checks.

**Ownership and Authorization Updates:**

* In `src/app/category/[id]/page.js`, the edit controls for a service are now shown only if the logged-in user's UID matches the service's `owner_uid`, instead of relying on an admin check. ([src/app/category/[id]/page.jsL68-R69](diffhunk://#diff-4e50b444ab900fd2e72b55a6233e9c803267382f4f3682782d89fb46354f84c6L68-R69))

**Service Creation and Form Logic:**

* In `src/components/forms/ServiceForm.js`, the form now uses the authenticated user's context (`useAuth`) to access the current user. [[1]](diffhunk://#diff-a2fd4a7509774a090b75a9d8ddca849f1b71ec63bab718e7a6bb456bb67ef69cR15-L17) [[2]](diffhunk://#diff-a2fd4a7509774a090b75a9d8ddca849f1b71ec63bab718e7a6bb456bb67ef69cR33)
* When creating a new service, the form sets the `owner_uid` property on the service payload to the current user's UID, ensuring ownership is tracked.
* The form initialization explicitly does not update `owner_uid` when editing an existing service, preventing unintended ownership changes.