### PR TITLE
Stylists can connect their Google Calendar and other improvements

### DIFF
--- a/src/api/oauthData.js
+++ b/src/api/oauthData.js
@@ -1,0 +1,25 @@
+import { clientCredentials } from '../utils/client';
+
+// Check current OAuth status
+const getOAuthStatus = (uid) =>
+  new Promise((resolve, reject) => {
+    fetch(`${clientCredentials.databaseURL}/oauth/google/status`, {
+      headers: { Authorization: uid },
+    })
+      .then((res) => res.json())
+      .then(resolve)
+      .catch(reject);
+  });
+
+// Start OAuth flow (returns URL for Google consent screen)
+const initiateOAuth = (uid) =>
+  new Promise((resolve, reject) => {
+    fetch(`${clientCredentials.databaseURL}/oauth/google/initiate`, {
+      headers: { Authorization: uid },
+    })
+      .then((res) => res.json())
+      .then(resolve)
+      .catch(reject);
+  });
+
+export { getOAuthStatus, initiateOAuth };

--- a/src/app/stylists/page.js
+++ b/src/app/stylists/page.js
@@ -6,10 +6,10 @@ import Link from 'next/link';
 import { useAuth } from '../../utils/context/authContext';
 import { getStylists } from '../../api/userData';
 import { getServicesByStylist } from '../../api/servicesData';
+import StylistOAuthTile from '../../components/StylistOAuthTile';
 
 export default function PublicStylistsPage() {
   const { user } = useAuth();
-  console.log('user: ', user);
 
   const [stylists, setStylists] = useState([]);
   const [servicesByStylist, setServicesByStylist] = useState({});
@@ -17,7 +17,6 @@ export default function PublicStylistsPage() {
   useEffect(() => {
     getStylists().then(setStylists);
   }, []);
-  console.log('stylists: ', stylists);
 
   useEffect(() => {
     getStylists().then((list) => {
@@ -34,6 +33,9 @@ export default function PublicStylistsPage() {
     <div className="bg-white">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">Our Stylists</h1>
+
+        {/* Show tile only if logged-in user is a stylist */}
+        {user?.role === 'stylist' && <StylistOAuthTile />}
 
         {stylists.map((stylist) => {
           const services = servicesByStylist[stylist.id];

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,42 +1,57 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
-import { Navbar, Container, Nav, Button } from 'react-bootstrap';
+import { Navbar, Container, Nav, Button, Toast, ToastContainer } from 'react-bootstrap';
 import { signOut, signIn } from '../utils/authentication';
 import { useAuth } from '../utils/context/authContext';
 
 export default function NavBar() {
   const { user } = useAuth();
+  const [showToast, setShowToast] = useState(false);
+
+  const handleSignOut = () => {
+    signOut();
+    // show toast notification on sign out
+    setShowToast(true);
+  };
 
   return (
-    <Navbar collapseOnSelect expand="lg" bg="light" variant="light">
-      <Container>
-        <Link passHref href="/" className="navbar-brand brand-cute">
-          Tress Relief
-        </Link>
-        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-        <Navbar.Collapse id="responsive-navbar-nav">
-          <Nav className="me-auto">
-            {/* CLOSE NAVBAR ON LINK SELECTION: https://stackoverflow.com/questions/72813635/collapse-on-select-react-bootstrap-navbar-with-nextjs-not-working */}
-            <Link className="nav-link" href="/" style={{ color: 'black' }}>
-              Services
-            </Link>
+    <>
+      <Navbar collapseOnSelect expand="lg" bg="light" variant="light">
+        <Container>
+          <Link passHref href="/" className="navbar-brand brand-cute">
+            Tress Relief
+          </Link>
+          <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+          <Navbar.Collapse id="responsive-navbar-nav">
+            <Nav className="me-auto">
+              {/* CLOSE NAVBAR ON LINK SELECTION: https://stackoverflow.com/questions/72813635/collapse-on-select-react-bootstrap-navbar-with-nextjs-not-working */}
+              <Link className="nav-link" href="/" style={{ color: 'black' }}>
+                Services
+              </Link>
 
-            <Link className="nav-link" href="/stylists" style={{ color: 'black' }}>
-              Meet the Stylists
-            </Link>
-          </Nav>
-          {user ? (
-            <Button variant="danger" onClick={signOut}>
-              Sign Out
-            </Button>
-          ) : (
-            <Button variant="primary" onClick={signIn}>
-              Sign In
-            </Button>
-          )}
-        </Navbar.Collapse>
-      </Container>
-    </Navbar>
+              <Link className="nav-link" href="/stylists" style={{ color: 'black' }}>
+                Meet the Stylists
+              </Link>
+            </Nav>
+            {user ? (
+              <Button variant="danger" onClick={handleSignOut}>
+                Sign Out
+              </Button>
+            ) : (
+              <Button variant="primary" onClick={signIn}>
+                Sign In
+              </Button>
+            )}
+          </Navbar.Collapse>
+        </Container>
+      </Navbar>
+
+      <ToastContainer position="top-center" className="p-3">
+        <Toast bg="success" show={showToast} onClose={() => setShowToast(false)} delay={3000} autohide>
+          <Toast.Body>Signed out successfully</Toast.Body>
+        </Toast>
+      </ToastContainer>
+    </>
   );
 }

--- a/src/components/StylistOAuthTile.js
+++ b/src/components/StylistOAuthTile.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-nested-ternary */
+import { useEffect, useState } from 'react';
+import { Button, Card, Spinner } from 'react-bootstrap';
+import { useAuth } from '@/utils/context/authContext';
+import { getOAuthStatus, initiateOAuth } from '@/api/oauthData';
+
+export default function StylistOAuthTile() {
+  const { user } = useAuth();
+  const [status, setStatus] = useState({ connected: false, calendar_id: null });
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (user?.uid) {
+      getOAuthStatus(user.uid)
+        .then(setStatus)
+        .catch(() => setStatus({ connected: false }))
+        .finally(() => setLoading(false));
+    }
+  }, [user]);
+
+  const handleConnect = () => {
+    initiateOAuth(user.uid).then((data) => {
+      // successful oauth inititation returns { url: 'https://accounts.google.com/....' } (consent screen)
+      if (data.url) {
+        window.location.href = data.url; // redirect stylist to Google consent
+      }
+    });
+  };
+
+  return (
+    <div>
+      <Card className="mb-3 p-3">
+        <h5>Hi, {user?.display_name}! Your Stylist Google Calendar:</h5>
+
+        {loading ? (
+          <Spinner animation="border" size="sm" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </Spinner>
+        ) : status?.connected ? (
+          <p>✅ Connected to calendar: {status.calendar_id || 'primary'}</p>
+        ) : (
+          <>
+            <p>⚠️ Not connected</p>
+            <Button variant="primary" onClick={handleConnect}>
+              Connect Calendar
+            </Button>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/StylistOAuthTile.js
+++ b/src/components/StylistOAuthTile.js
@@ -23,6 +23,8 @@ export default function StylistOAuthTile() {
       // successful oauth inititation returns { url: 'https://accounts.google.com/....' } (consent screen)
       if (data.url) {
         window.location.href = data.url; // redirect stylist to Google consent
+        // and then back to our backend /oauth/google/callback to finish the process
+        // which will then redirect back to the front-end /stylists page
       }
     });
   };

--- a/src/components/StylistOAuthTile.js
+++ b/src/components/StylistOAuthTile.js
@@ -33,6 +33,9 @@ export default function StylistOAuthTile() {
     <div>
       <Card className="mb-3 p-3">
         <h5>Hi, {user?.display_name}! Your Stylist Google Calendar:</h5>
+        <p className="text-muted" style={{ fontSize: '0.9rem' }}>
+          Connect your Google Calendar so clients can only book when you’re free. We’ll read your busy times and add appointments to your calendar automatically.
+        </p>
 
         {loading ? (
           <Spinner animation="border" size="sm" role="status">


### PR DESCRIPTION
This pull request introduces Google Calendar OAuth integration for stylists, allowing them to connect their calendar for appointment management. The main changes include new API methods for OAuth, a UI tile for stylists to connect their calendar, and a notification toast on sign out. These updates improve the user experience for stylists and add calendar connectivity features.

**Google Calendar OAuth Integration**
* Added `getOAuthStatus` and `initiateOAuth` API functions in `src/api/oauthData.js` to check OAuth status and initiate the Google OAuth flow for calendar connection.
* Created the `StylistOAuthTile` component in `src/components/StylistOAuthTile.js` that displays the current OAuth status and allows stylists to connect their Google Calendar.
* Updated `src/app/stylists/page.js` to import and conditionally render `StylistOAuthTile` for users with the stylist role. [[1]](diffhunk://#diff-e5a3af04ec1765132921fed085a22c43f6250d29c8f53ba0d9ed0971ff386d92R9-L20) [[2]](diffhunk://#diff-e5a3af04ec1765132921fed085a22c43f6250d29c8f53ba0d9ed0971ff386d92R37-R39)

**User Experience Improvements**
* Added a toast notification in `src/components/NavBar.js` to inform users when they have signed out successfully. [[1]](diffhunk://#diff-c25cbd82eca26fc9714051e991f00bea997778601a72fc7d3b49952c46c09e38L2-R19) [[2]](diffhunk://#diff-c25cbd82eca26fc9714051e991f00bea997778601a72fc7d3b49952c46c09e38L30-R38) [[3]](diffhunk://#diff-c25cbd82eca26fc9714051e991f00bea997778601a72fc7d3b49952c46c09e38R49-R55)